### PR TITLE
support local union, struct, and enum declarations inside functions

### DIFF
--- a/src/parser/parser_stmt.c
+++ b/src/parser/parser_stmt.c
@@ -2587,6 +2587,19 @@ ASTNode *parse_statement(ParserContext *ctx, Lexer *l)
     {
         return parse_impl(ctx, l);
     }
+    if (tk.type == TOK_IDENT && strncmp(tk.start, "struct", 6) == 0 && tk.len == 6)
+    {
+        return parse_struct(ctx, l, 0, 0);
+    }
+    if (tk.type == TOK_UNION)
+    {
+        return parse_struct(ctx, l, 1, 0);
+    }
+    if (tk.type == TOK_IDENT && strncmp(tk.start, "enum", 4) == 0 && tk.len == 4)
+    {
+        return parse_enum(ctx, l);
+    }
+
     if (tk.type == TOK_AUTOFREE)
     {
         lexer_next(l);

--- a/src/parser/parser_struct.c
+++ b/src/parser/parser_struct.c
@@ -864,6 +864,7 @@ ASTNode *parse_struct(ParserContext *ctx, Lexer *l, int is_union, int is_opaque)
     {
         lexer_next(l);
         ASTNode *node = ast_create(NODE_STRUCT);
+        node->token = name_token;
         node->strct.name = name;
         node->strct.is_template = (gp_count > 0);
         node->strct.generic_params = gps;
@@ -1053,6 +1054,7 @@ ASTNode *parse_struct(ParserContext *ctx, Lexer *l, int is_union, int is_opaque)
     }
 
     ASTNode *node = ast_create(NODE_STRUCT);
+    node->token = name_token;
     add_to_struct_list(ctx, node);
 
     node->strct.name = name;
@@ -1120,6 +1122,7 @@ ASTNode *parse_enum(ParserContext *ctx, Lexer *l)
     lexer_next(l);
     Token n = lexer_next(l);
     check_identifier(ctx, n);
+    Token name_token = n;
 
     char *gp = NULL;
     if (lexer_peek(l).type == TOK_LANGLE)
@@ -1277,6 +1280,7 @@ ASTNode *parse_enum(ParserContext *ctx, Lexer *l)
     }
 
     ASTNode *node = ast_create(NODE_ENUM);
+    node->token = name_token;
     node->enm.name = ename;
 
     node->enm.variants = h;

--- a/tests/compiler/codegen/emit_source_mapping.zc
+++ b/tests/compiler/codegen/emit_source_mapping.zc
@@ -43,11 +43,32 @@ fn main() {
     let log = Log {};
     log.verbose("Hello, mars!");
 
+    struct LocalPoint {
+        x: int;
+        y: int;
+    }
+
+    enum LocalState {
+        Ready,
+        Busy,
+    }
+
+    union LocalValue {
+        i: int;
+    }
+
+    let local_point = LocalPoint { x: 3, y: 4 };
+    let local_state = LocalState::Ready;
+    let local_value = LocalValue { i: 8 };
+
     let point = Point {
         x: (f64)my_function(),
         y: 512.0,
     };
     point.mark_unused();
+    assert(local_point.x == 3, "local struct failed");
+    assert(local_state == LocalState::Ready, "local enum failed");
+    assert(local_value.i == 8, "local union failed");
 
     for(let i = 0; i < 10; ++i)
     {


### PR DESCRIPTION
## Description
This PR adds support for local `struct`, `union`, and `enum` declarations inside function and block scope, including `main()`.

Before this change, Zen C already supported these declarations at top level, but `parse_statement(...)` did not recognize them in statement position. That meant code such as local type declarations inside `main()` or other function bodies could not be parsed correctly even though the rest of the pipeline already had supporting pieces for handling these nodes.

This change updates statement parsing so local `struct`, `union`, and `enum` declarations are accepted inside blocks. It also assigns source tokens to the generated struct/enum AST nodes so debug/source-mapping mode does not emit source mapping warnings for these local declarations.

A regression test was added to cover local type declarations in the source-mapping/codegen path.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Validation
- `make`
- `bash tests/scripts/run_codegen_tests.sh`
- `./zc check tests/compiler/codegen/emit_source_mapping.zc -g --warn-errors`