### PR TITLE
Disable JIT compilation by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ else
     LIBS = -lm -lpthread -ldl
 endif
 
-ZC_HAS_JIT ?= 1
+ZC_HAS_JIT ?= 0
 ZC_RUN ?= ./zc
 ifeq ($(ZC_HAS_JIT), 1)
     CFLAGS += -DZC_HAS_JIT


### PR DESCRIPTION
Fixes #437 

This PR makes JIT support opt-in by default.

Currently, the default build enables `ZC_HAS_JIT`, which requires the TinyCC/libtcc development header:

```c
#include <libtcc.h>
```

On a clean Ubuntu/WSL environment, `libtcc.h` is usually not installed, so the default `make` command fails.

This PR changes the default behavior so that a normal build does not require libtcc unless JIT support is explicitly enabled.

## Changes

* Change the default value of `ZC_HAS_JIT` from enabled to disabled.
* Define `ZC_HAS_JIT` explicitly as either `0` or `1`.

## Testing

Tested the default build without libtcc installed:

```bash
make clean
make
```

Tested explicitly disabling JIT:

```bash
make clean
make ZC_HAS_JIT=0
```

Both builds succeed without requiring `libtcc.h`.

JIT can still be enabled explicitly with:

```bash
make ZC_HAS_JIT=1
```

In that case, libtcc development headers are still required.


